### PR TITLE
split requirement to install and test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,6 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-install_require = ['redis', 'hiredis']
-
-test_require = ['rmtest']
 
 setup(
     name='redisearch',
@@ -13,8 +10,8 @@ setup(
     description='RedisSearch Python Client',
     url='http://github.com/RedisLabs/redisearch-py',
     packages=find_packages(),
-    install_requires=install_requires,
-    test_require=test_require,
+    install_requires=['redis', 'hiredis'],
+    test_require=['rmtest'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
+install_require = ['redis', 'hiredis']
+
+test_require = ['rmtest']
 
 setup(
     name='redisearch',
@@ -10,7 +13,8 @@ setup(
     description='RedisSearch Python Client',
     url='http://github.com/RedisLabs/redisearch-py',
     packages=find_packages(),
-    install_requires=['redis', 'hiredis', 'rmtest'],
+    install_requires=install_requires,
+    test_require=test_require,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I just tried to generate a rpm packge from  this repo use **fpm** . It shows that there are some conflicts between rmtest and redisearch-py.

Delete rmtest from `install_requires` can fix this issue.